### PR TITLE
Editor Event Bus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,9 @@ build/*
 # Editor PIE temp snapshots (project-root-relative under EditorTemp/)
 EditorTemp/
 
+#shmup
+SimpleShmup/Assets/*
+
 #Claude AI
 .claude/CLAUDE.local.md
 .claude/task/*

--- a/Engine/Source/Core/Event/OpaaxEventTypes.hpp
+++ b/Engine/Source/Core/Event/OpaaxEventTypes.hpp
@@ -55,6 +55,16 @@ namespace Opaax
         //   The subsystem filter (GetEventCategoryFilter) ensures engine subsystems
         //   never receive gameplay events even if entries are interleaved.
         GameplayEvent = 1000,  // sentinel — reserve space, avoid collisions
+
+        // --- Editor (editor-only; gated by OPAAX_WITH_EDITOR at consumer sites) ---
+        // NOTE: Editor events flow through EditorEventBus, NOT through the engine
+        //   subsystem dispatch path. The sentinel exists here only to keep the
+        //   global EEventType space collision-free.
+        EditorEvent = 2000,  // sentinel
+        EntitySelected,
+        SceneSaved,
+        NewScene,
+        AssetImported,
     };
  
     // =============================================================================
@@ -78,6 +88,7 @@ namespace Opaax
         EEventCategory_Mouse       = BIT(3),   // mouse move / scroll
         EEventCategory_MouseButton = BIT(4),   // mouse button press/release
         EEventCategory_Gameplay    = BIT(5),   // game-layer events (not used by engine subsystems)
-        // BIT(6..31) reserved for future engine domains or game extension
+        EEventCategory_Editor      = BIT(6),   // editor-only events dispatched via EditorEventBus
+        // BIT(7..31) reserved for future engine domains or game extension
     };
 }

--- a/Engine/Source/Editor/EditorEventBus.cpp
+++ b/Engine/Source/Editor/EditorEventBus.cpp
@@ -1,0 +1,105 @@
+#include "Editor/EditorEventBus.h"
+
+#if OPAAX_WITH_EDITOR
+
+#include <algorithm>
+
+#include "Core/Log/OpaaxLog.h"
+
+namespace Opaax::Editor
+{
+    // =============================================================================
+    // SubscriptionToken
+    // =============================================================================
+
+    SubscriptionToken::~SubscriptionToken()
+    {
+        Reset();
+    }
+
+    SubscriptionToken::SubscriptionToken(SubscriptionToken&& Other) noexcept
+        : m_Bus(Other.m_Bus), m_Type(Other.m_Type), m_ID(Other.m_ID)
+    {
+        Other.m_Bus  = nullptr;
+        Other.m_Type = EEventType::None;
+        Other.m_ID   = 0;
+    }
+
+    SubscriptionToken& SubscriptionToken::operator=(SubscriptionToken&& Other) noexcept
+    {
+        if (this != &Other)
+        {
+            Reset();
+            m_Bus        = Other.m_Bus;
+            m_Type       = Other.m_Type;
+            m_ID         = Other.m_ID;
+            Other.m_Bus  = nullptr;
+            Other.m_Type = EEventType::None;
+            Other.m_ID   = 0;
+        }
+        return *this;
+    }
+
+    void SubscriptionToken::Reset() noexcept
+    {
+        if (m_Bus != nullptr)
+        {
+            m_Bus->Unsubscribe(m_Type, m_ID);
+            m_Bus  = nullptr;
+            m_Type = EEventType::None;
+            m_ID   = 0;
+        }
+    }
+
+    // =============================================================================
+    // EditorEventBus
+    // =============================================================================
+
+    EditorEventBus::~EditorEventBus()
+    {
+        for (const auto& [lType, lBucket] : m_Handlers)
+        {
+            if (!lBucket.empty())
+            {
+                OPAAX_CORE_ERROR(
+                    "EditorEventBus dtor: subscribers still registered for EEventType={} (count={}). "
+                    "Token leak or lifetime inversion (token outlived the bus).",
+                    static_cast<Uint32>(lType), lBucket.size());
+                OPAAX_ASSERT(lBucket.empty());
+            }
+        }
+    }
+
+    void EditorEventBus::Publish(const OpaaxEvent& InEvent)
+    {
+        const auto lIt = m_Handlers.find(InEvent.GetEventType());
+        if (lIt == m_Handlers.end()) { return; }
+
+        // Snapshot the bucket — a handler may publish or (un)subscribe during dispatch,
+        // mutating m_Handlers under our feet. Iterating a copy keeps delivery stable.
+        const auto lSnapshot = lIt->second;
+        for (const auto& lEntry : lSnapshot)
+        {
+            lEntry.Handler(InEvent);
+        }
+    }
+
+    void EditorEventBus::Unsubscribe(EEventType InType, Uint64 InID)
+    {
+        const auto lIt = m_Handlers.find(InType);
+        if (lIt == m_Handlers.end()) { return; }
+
+        auto& lBucket = lIt->second;
+        lBucket.erase(
+            std::remove_if(lBucket.begin(), lBucket.end(),
+                [InID](const HandlerEntry& InEntry) { return InEntry.ID == InID; }),
+            lBucket.end());
+
+        if (lBucket.empty())
+        {
+            m_Handlers.erase(lIt);
+        }
+    }
+}
+
+#endif // OPAAX_WITH_EDITOR

--- a/Engine/Source/Editor/EditorEventBus.h
+++ b/Engine/Source/Editor/EditorEventBus.h
@@ -1,0 +1,162 @@
+#pragma once
+
+#if OPAAX_WITH_EDITOR
+
+#include <functional>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "Core/EngineAPI.h"
+#include "Core/Event/OpaaxEvent.hpp"
+#include "Core/Event/OpaaxEventTypes.hpp"
+#include "Core/OpaaxTypes.h"
+
+namespace Opaax::Editor
+{
+    class EditorEventBus;
+
+    // =============================================================================
+    // SubscriptionToken
+    // =============================================================================
+
+    /**
+     * @class SubscriptionToken
+     * RAII unsubscribe handle returned by EditorEventBus::Subscribe.
+     *
+     * Move-only. Dtor calls back into the bus and removes the registration.
+     *
+     * Lifetime invariant: a SubscriptionToken MUST NOT outlive its owning
+     * EditorEventBus. Under the editor's ownership graph this is guaranteed —
+     * panels are owned by EditorSubsystem, the bus is owned by EditorSubsystem,
+     * and panel destruction runs before bus destruction. The bus dtor asserts
+     * the registry is empty as a tripwire for that invariant.
+     */
+    class OPAAX_API SubscriptionToken final
+    {
+        // =============================================================================
+        // CTORs - DTOR
+        // =============================================================================
+    public:
+        SubscriptionToken() noexcept = default;
+        SubscriptionToken(EditorEventBus* InBus, EEventType InType, Uint64 InID) noexcept
+            : m_Bus(InBus), m_Type(InType), m_ID(InID)
+        {}
+        ~SubscriptionToken();
+
+        // =============================================================================
+        // Copy - Delete
+        // =============================================================================
+        SubscriptionToken(const SubscriptionToken&)            = delete;
+        SubscriptionToken& operator=(const SubscriptionToken&) = delete;
+
+        // =============================================================================
+        // Move
+        // =============================================================================
+        SubscriptionToken(SubscriptionToken&& Other) noexcept;
+        SubscriptionToken& operator=(SubscriptionToken&& Other) noexcept;
+
+        // =============================================================================
+        // Functions
+        // =============================================================================
+    public:
+        /** Cancels the subscription early (idempotent). */
+        void Reset() noexcept;
+
+        FORCEINLINE bool IsValid() const noexcept { return m_Bus != nullptr; }
+
+        // =============================================================================
+        // Members
+        // =============================================================================
+    private:
+        EditorEventBus* m_Bus  = nullptr;
+        EEventType      m_Type = EEventType::None;
+        Uint64          m_ID   = 0;
+    };
+
+    // =============================================================================
+    // EditorEventBus
+    // =============================================================================
+
+    /**
+     * @class EditorEventBus
+     * Editor-only pub/sub bus. Type-keyed — subscribers register against a single
+     * concrete event type and only receive events of that type.
+     *
+     * Dispatch is immediate-synchronous: Publish walks the bucket for
+     * event.GetEventType() and calls each handler in registration order.
+     * The bucket is snapshotted before iteration so subscribers may publish or
+     * (un)subscribe during dispatch without invalidating iteration.
+     *
+     * Owned by EditorSubsystem. Editor-only — gated by OPAAX_WITH_EDITOR.
+     * Non-movable: SubscriptionTokens hold a raw EditorEventBus* and a move
+     * would silently dangle them.
+     */
+    class OPAAX_API EditorEventBus final
+    {
+        // =============================================================================
+        // CTORs - DTOR
+        // =============================================================================
+    public:
+        EditorEventBus() = default;
+        ~EditorEventBus();
+
+        // =============================================================================
+        // Copy - Move - Delete
+        // =============================================================================
+        EditorEventBus(const EditorEventBus&)            = delete;
+        EditorEventBus& operator=(const EditorEventBus&) = delete;
+        EditorEventBus(EditorEventBus&&)                 = delete;
+        EditorEventBus& operator=(EditorEventBus&&)      = delete;
+
+        // =============================================================================
+        // Functions
+        // =============================================================================
+    public:
+        /**
+         * Register a handler for a concrete event type.
+         * @param Callback void(const TEvent&) — receives the down-cast event.
+         * @return SubscriptionToken — keep it alive for as long as the subscription should persist.
+         */
+        template<typename TEvent>
+        SubscriptionToken Subscribe(std::function<void(const TEvent&)> Callback)
+        {
+            static_assert(std::is_base_of_v<OpaaxEvent, TEvent>,
+                "EditorEventBus::Subscribe: TEvent must derive from OpaaxEvent");
+
+            const EEventType lType = TEvent::GetStaticType();
+            const Uint64     lID   = ++m_NextID;
+
+            auto lShim = [Cb = std::move(Callback)](const OpaaxEvent& InEvent)
+            {
+                Cb(static_cast<const TEvent&>(InEvent));
+            };
+
+            m_Handlers[lType].push_back({lID, std::move(lShim)});
+            return SubscriptionToken{this, lType, lID};
+        }
+
+        /** Synchronous dispatch. Safe under reentrant publish / (un)subscribe. */
+        void Publish(const OpaaxEvent& InEvent);
+
+        // =============================================================================
+        // Members
+        // =============================================================================
+    private:
+        friend class SubscriptionToken;
+        void Unsubscribe(EEventType InType, Uint64 InID);
+
+        struct HandlerEntry
+        {
+            Uint64                                 ID;
+            std::function<void(const OpaaxEvent&)> Handler;
+        };
+
+        std::unordered_map<EEventType, std::vector<HandlerEntry>> m_Handlers;
+        Uint64                                                    m_NextID = 0;
+    };
+
+} // namespace Opaax::Editor
+
+#endif // OPAAX_WITH_EDITOR

--- a/Engine/Source/Editor/EditorSubsystem.cpp
+++ b/Engine/Source/Editor/EditorSubsystem.cpp
@@ -22,10 +22,14 @@
 #include "Editor/Assets/Types/SceneTypeActions.h"
 #include "Editor/Assets/Types/Texture2DTypeActions.h"
 #include "Editor/Events/EditorEvents.h"
-#include "Editor/Inspector/ComponentDrawerRegistry.h"
 #include "Editor/Inspector/Drawers/TagDrawer.h"
 #include "Editor/Inspector/Drawers/TransformDrawer.h"
 #include "Editor/Inspector/Drawers/SpriteDrawer.h"
+
+#include "ECS/ComponentRegistry.h"
+#include "ECS/Components/TagComponent.h"
+#include "ECS/Components/TransformComponent.h"
+#include "ECS/Components/SpriteComponent.h"
 
 namespace Opaax
 {
@@ -98,9 +102,9 @@ namespace Opaax
 
     void EditorSubsystem::RegisterComponentDrawers()
     {
-        Editor::ComponentDrawerRegistry::Register(MakeUnique<Editor::TagDrawer>());
-        Editor::ComponentDrawerRegistry::Register(MakeUnique<Editor::TransformDrawer>());
-        Editor::ComponentDrawerRegistry::Register(MakeUnique<Editor::SpriteDrawer>());
+        ComponentRegistry::RegisterDrawer<ECS::TagComponent>      (MakeUnique<Editor::TagDrawer>());
+        ComponentRegistry::RegisterDrawer<ECS::TransformComponent>(MakeUnique<Editor::TransformDrawer>());
+        ComponentRegistry::RegisterDrawer<ECS::SpriteComponent>   (MakeUnique<Editor::SpriteDrawer>());
 
         OPAAX_CORE_TRACE("EditorSubsystem: component drawers registered.");
     }
@@ -133,7 +137,7 @@ namespace Opaax
         OPAAX_CORE_INFO("EditorSubsystem::Shutdown()");
 
         Editor::AssetTypeRegistry::Clear();
-        Editor::ComponentDrawerRegistry::Clear();
+        ComponentRegistry::Clear();
 
         m_ViewportPanel.Shutdown();
 

--- a/Engine/Source/Editor/EditorSubsystem.cpp
+++ b/Engine/Source/Editor/EditorSubsystem.cpp
@@ -239,14 +239,6 @@ namespace Opaax
     }
 
     // =============================================================================
-    // Asset browser refresh
-    // =============================================================================
-    void EditorSubsystem::RefreshAssetBrowser()
-    {
-        m_AssetBrowserPanel.RunScan();
-    }
-
-    // =============================================================================
     // PIE state machine
     // =============================================================================
     void EditorSubsystem::SetEditorState(Editor::EEditorState NewState)

--- a/Engine/Source/Editor/EditorSubsystem.cpp
+++ b/Engine/Source/Editor/EditorSubsystem.cpp
@@ -233,7 +233,7 @@ namespace Opaax
         World* lWorld       = lActiveScene ? &GetEngineApp()->GetWorld() : nullptr;
 
         if (m_bShowHierarchy)    m_HierarchyPanel.Draw(lActiveScene, lWorld);
-        if (m_bShowInspector)    m_InspectorPanel.Draw(lWorld, m_HierarchyPanel.GetSelectedEntity());
+        if (m_bShowInspector)    m_InspectorPanel.Draw(lWorld);
         if (m_bShowViewport)     m_ViewportPanel.Draw(m_EditorState);
         if (m_bShowAssetBrowser) m_AssetBrowserPanel.Draw(lSceneMgr);
     }

--- a/Engine/Source/Editor/EditorSubsystem.cpp
+++ b/Engine/Source/Editor/EditorSubsystem.cpp
@@ -194,19 +194,23 @@ namespace Opaax
 
     void EditorSubsystem::DrawPanels()
     {
-        auto* lSceneMgr = GetEngineApp()
+        SceneManager* lSceneMgr = GetEngineApp()
             ? GetEngineApp()->GetSubsystem<SceneManager>()
             : nullptr;
-
-        Scene* lActiveScene = lSceneMgr ? lSceneMgr->GetActiveScene() : nullptr;
-        World* lWorld       = lActiveScene ? &GetEngineApp()->GetWorld() : nullptr;
+        if (!lSceneMgr) { return; }
 
         m_MainMenuBar.Draw(*this);
 
-        if (m_bShowHierarchy)    m_HierarchyPanel.Draw(lActiveScene, lWorld);
+        // World is owned by CoreEngineApp — stable across MainMenuBar mutations
+        // (scene transitions only swap entities, not the World container). Each
+        // panel that needs the active Scene fetches it just-in-time from SceneMgr
+        // (HierarchyPanel, AssetBrowserPanel) — no broker-level Scene* cache.
+        World& lWorld = GetEngineApp()->GetWorld();
+
+        if (m_bShowHierarchy)    m_HierarchyPanel.Draw(*lSceneMgr, lWorld);
         if (m_bShowInspector)    m_InspectorPanel.Draw(lWorld);
         if (m_bShowViewport)     m_ViewportPanel.Draw(m_EditorState);
-        if (m_bShowAssetBrowser) m_AssetBrowserPanel.Draw(lSceneMgr);
+        if (m_bShowAssetBrowser) m_AssetBrowserPanel.Draw(*lSceneMgr);
     }
 
     // =============================================================================

--- a/Engine/Source/Editor/EditorSubsystem.cpp
+++ b/Engine/Source/Editor/EditorSubsystem.cpp
@@ -9,13 +9,9 @@
 #include <imgui_impl_glfw.h>
 #include <imgui_impl_opengl3.h>
 
-#include <fstream>
-#include <nlohmann/json.hpp>
-
 #include "Core/CoreEngineApp.h"
 #include "Core/OpaaxPath.h"
 #include "Core/Window.h"
-#include "Scene/SceneFactory.h"
 #include "Scene/SceneManager.h"
 #include "Scene/SceneSerializer.h"
 #include "Core/Log/OpaaxLog.h"
@@ -25,37 +21,18 @@
 #include "Editor/Assets/AssetTypeRegistry.h"
 #include "Editor/Assets/Types/SceneTypeActions.h"
 #include "Editor/Assets/Types/Texture2DTypeActions.h"
+#include "Editor/Events/EditorEvents.h"
+#include "Editor/Inspector/ComponentDrawerRegistry.h"
 #include "Editor/Inspector/Drawers/TagDrawer.h"
 #include "Editor/Inspector/Drawers/TransformDrawer.h"
 #include "Editor/Inspector/Drawers/SpriteDrawer.h"
 
-#include "ECS/ComponentRegistry.h"
-#include "ECS/Components/TagComponent.h"
-#include "ECS/Components/TransformComponent.h"
-#include "ECS/Components/SpriteComponent.h"
-
 namespace Opaax
 {
     // =============================================================================
-    // PIE — temp snapshot files used for Play→Stop scene-stack restore
-    //
-    // PIE_TEMP_MANIFEST_PATH stores the stack metadata (one entry per scene with
-    // its SceneFactory name + the path to its per-scene entity dump). Per-scene
-    // entity dumps live alongside as PlaySession_<i>.json. On Stop we pop the
-    // entire current stack and rebuild from the manifest via SceneFactory —
-    // tolerates games that Push/Replace scenes during PIE.
+    // PIE — temp snapshot file used for Play→Stop scene restore
     // =============================================================================
-    static constexpr const char* PIE_TEMP_MANIFEST_PATH    = "EditorTemp/PlaySession.json";
-    static constexpr const char* PIE_TEMP_SCENE_DIR        = "EditorTemp";
-    static constexpr const char* PIE_TEMP_PERSISTENTS_PATH = "EditorTemp/PlaySession_persistent.json";
-    static constexpr int         PIE_MANIFEST_VERSION      = 1;
-
-    static OpaaxString MakePerScenePath(Uint32 InIndex)
-    {
-        char lBuf[64];
-        std::snprintf(lBuf, sizeof(lBuf), "%s/PlaySession_%u.json", PIE_TEMP_SCENE_DIR, InIndex);
-        return OpaaxPath::ToAbsolute(lBuf);
-    }
+    static constexpr const char* PIE_TEMP_SCENE_PATH = "EditorTemp/PlaySession.json";
 
     // =============================================================================
     // Startup
@@ -121,12 +98,9 @@ namespace Opaax
 
     void EditorSubsystem::RegisterComponentDrawers()
     {
-        // Component types themselves are registered by CoreEngineApp::Initialize.
-        // Here we only attach custom drawers — components without one fall back to
-        // ComponentRegistry's default read-only json renderer.
-        ComponentRegistry::RegisterDrawer<ECS::TagComponent>      (MakeUnique<Editor::TagDrawer>());
-        ComponentRegistry::RegisterDrawer<ECS::TransformComponent>(MakeUnique<Editor::TransformDrawer>());
-        ComponentRegistry::RegisterDrawer<ECS::SpriteComponent>   (MakeUnique<Editor::SpriteDrawer>());
+        Editor::ComponentDrawerRegistry::Register(MakeUnique<Editor::TagDrawer>());
+        Editor::ComponentDrawerRegistry::Register(MakeUnique<Editor::TransformDrawer>());
+        Editor::ComponentDrawerRegistry::Register(MakeUnique<Editor::SpriteDrawer>());
 
         OPAAX_CORE_TRACE("EditorSubsystem: component drawers registered.");
     }
@@ -159,7 +133,7 @@ namespace Opaax
         OPAAX_CORE_INFO("EditorSubsystem::Shutdown()");
 
         Editor::AssetTypeRegistry::Clear();
-        ComponentRegistry::Clear();
+        Editor::ComponentDrawerRegistry::Clear();
 
         m_ViewportPanel.Shutdown();
 
@@ -224,13 +198,10 @@ namespace Opaax
             ? GetEngineApp()->GetSubsystem<SceneManager>()
             : nullptr;
 
-        // MainMenuBar can mutate the scene stack (Stop → ExitPlayMode pops+rebuilds,
-        // Open/New/LoadScene swap the active scene). Capture the post-Draw state so
-        // downstream panels never dereference a Scene* the toolbar just destroyed.
-        m_MainMenuBar.Draw(*this);
-
         Scene* lActiveScene = lSceneMgr ? lSceneMgr->GetActiveScene() : nullptr;
         World* lWorld       = lActiveScene ? &GetEngineApp()->GetWorld() : nullptr;
+
+        m_MainMenuBar.Draw(*this);
 
         if (m_bShowHierarchy)    m_HierarchyPanel.Draw(lActiveScene, lWorld);
         if (m_bShowInspector)    m_InspectorPanel.Draw(lWorld);
@@ -262,54 +233,18 @@ namespace Opaax
         }
 
         SceneManager* lSceneMgr = GetEngineApp() ? GetEngineApp()->GetSceneManager() : nullptr;
-        if (!lSceneMgr || lSceneMgr->GetStackDepth() == 0)
+        if (!lSceneMgr || !lSceneMgr->GetActiveScene())
         {
-            OPAAX_CORE_WARN("EditorSubsystem::EnterPlayMode — empty scene stack, aborting.");
+            OPAAX_CORE_WARN("EditorSubsystem::EnterPlayMode — no active scene, aborting.");
             return;
         }
 
-        const OpaaxString lManifestPath = OpaaxPath::ToAbsolute(PIE_TEMP_MANIFEST_PATH);
+        const OpaaxString lTempPath = OpaaxPath::ToAbsolute(PIE_TEMP_SCENE_PATH);
         std::filesystem::create_directories(
-            std::filesystem::path(lManifestPath.CStr()).parent_path());
+            std::filesystem::path(lTempPath.CStr()).parent_path());
 
-        // Snapshot every scene on the stack, bottom-to-top, into its own file.
-        // The manifest records (scene-name → per-scene-file) so ExitPlayMode can
-        // rebuild the stack via SceneFactory even if PIE pushed/popped scenes.
-        nlohmann::json lManifest;
-        lManifest["version"] = PIE_MANIFEST_VERSION;
-        lManifest["stack"]   = nlohmann::json::array();
+        SceneSerializer::Serialize(*lSceneMgr->GetActiveScene(), lTempPath.CStr(), GetEngineApp()->GetWorld());
 
-        const Uint32 lDepth = lSceneMgr->GetStackDepth();
-        for (Uint32 i = 0; i < lDepth; ++i)
-        {
-            Scene* lScene = lSceneMgr->GetSceneAt(i);
-            OPAAX_CORE_ASSERT(lScene)
-
-            const OpaaxString lScenePath = MakePerScenePath(i);
-            SceneSerializer::Serialize(*lScene, lScenePath.CStr(), GetEngineApp()->GetWorld());
-
-            nlohmann::json lEntry;
-            lEntry["name"] = lScene->GetName().CStr();
-            lEntry["file"] = lScenePath.CStr();
-            lManifest["stack"].push_back(lEntry);
-        }
-
-        std::ofstream lFile(lManifestPath.CStr());
-        if (!lFile.is_open())
-        {
-            OPAAX_CORE_ERROR("EditorSubsystem::EnterPlayMode — cannot write PIE manifest '{}'.",
-                lManifestPath.CStr());
-            return;
-        }
-        lFile << lManifest.dump(4);
-
-        // Persistent-bucket snapshot — entities created via World::CreatePersistentEntity
-        // (SceneID == 0) are not inside any scene's bucket and must be captured separately
-        // so PIE Stop can roll back any mutations made during Play.
-        const OpaaxString lPersistentPath = OpaaxPath::ToAbsolute(PIE_TEMP_PERSISTENTS_PATH);
-        SceneSerializer::SerializePersistents(GetEngineApp()->GetWorld(), lPersistentPath.CStr());
-
-        OPAAX_CORE_INFO("EditorSubsystem::EnterPlayMode — snapshotted {} scene(s).", lDepth);
         SetEditorState(Editor::EEditorState::Playing);
     }
 
@@ -331,9 +266,6 @@ namespace Opaax
 
     void EditorSubsystem::ExitPlayMode()
     {
-        OPAAX_CORE_INFO("EditorSubsystem::ExitPlayMode — entered (state={})",
-            Editor::EditorStateToString(m_EditorState));
-
         if (m_EditorState == Editor::EEditorState::Editing)
         {
             OPAAX_CORE_WARN("EditorSubsystem::ExitPlayMode — already in Editing.");
@@ -341,122 +273,37 @@ namespace Opaax
         }
 
         SceneManager* lSceneMgr = GetEngineApp() ? GetEngineApp()->GetSceneManager() : nullptr;
-        if (!lSceneMgr)
+        if (!lSceneMgr || !lSceneMgr->GetActiveScene())
         {
-            OPAAX_CORE_WARN("EditorSubsystem::ExitPlayMode — no SceneManager.");
+            OPAAX_CORE_WARN("EditorSubsystem::ExitPlayMode — no active scene, dropping snapshot restore.");
             SetEditorState(Editor::EEditorState::Editing);
             return;
         }
 
-        const OpaaxString lManifestPath = OpaaxPath::ToAbsolute(PIE_TEMP_MANIFEST_PATH);
-        if (!std::filesystem::exists(lManifestPath.CStr()))
+        const OpaaxString lTempPath = OpaaxPath::ToAbsolute(PIE_TEMP_SCENE_PATH);
+        if (!std::filesystem::exists(lTempPath.CStr()))
         {
-            OPAAX_CORE_WARN("EditorSubsystem::ExitPlayMode — no PIE manifest found at {}",
-                lManifestPath.CStr());
+            OPAAX_CORE_WARN("EditorSubsystem::ExitPlayMode — no temp snapshot found at {}",
+                lTempPath.CStr());
             SetEditorState(Editor::EEditorState::Editing);
             return;
         }
 
-        // Read the manifest before we touch the stack — if anything fails we
-        // leave the current stack alone rather than tearing it down half-way.
-        nlohmann::json lManifest;
-        {
-            std::ifstream lIn(lManifestPath.CStr());
-            try
-            {
-                lIn >> lManifest;
-            }
-            catch (const nlohmann::json::parse_error& e)
-            {
-                OPAAX_CORE_ERROR("EditorSubsystem::ExitPlayMode — manifest parse failed: {}", e.what());
-                SetEditorState(Editor::EEditorState::Editing);
-                return;
-            }
-        }
-
-        if (!lManifest.contains("stack") || !lManifest["stack"].is_array())
-        {
-            OPAAX_CORE_ERROR("EditorSubsystem::ExitPlayMode — malformed manifest (missing 'stack' array).");
-            SetEditorState(Editor::EEditorState::Editing);
-            return;
-        }
-
-        // Tear down the current stack — destroys every play-mode scene entity.
-        // Persistent-tagged entities (SceneID == 0) pass through Pop() untouched
-        // (DestroyEntitiesWithSceneID never matches PersistentSceneID); they are
-        // rolled back further down via the persistent snapshot dance.
-        OPAAX_CORE_INFO("EditorSubsystem::ExitPlayMode — popping {} scene(s) from current stack.",
-            lSceneMgr->GetStackDepth());
-        while (lSceneMgr->GetStackDepth() > 0)
-        {
-            lSceneMgr->Pop();
-        }
-
-        // Rebuild bottom-to-top from the manifest. SceneFactory provides the
-        // C++ class identity for each entry; Push runs OnLoad (which may spawn
-        // initial entities); we wipe those and Deserialize the snapshotted set.
+        Scene* lScene = lSceneMgr->GetActiveScene();
         World& lWorld = GetEngineApp()->GetWorld();
-        Uint32 lRestored = 0;
+        // Scene stayed on the stack through PIE — its SceneID is unchanged, and
+        // World::m_ActiveSceneID already matches. Wipe only this scene's entities
+        // so any persistents survive the round-trip.
+        lWorld.DestroyEntitiesWithSceneID(lScene->GetSceneID());
+        SceneSerializer::Deserialize(*lScene, lTempPath.CStr(), lWorld);
 
-        for (const auto& lEntry : lManifest["stack"])
-        {
-            if (!lEntry.contains("name") || !lEntry.contains("file"))
-            {
-                OPAAX_CORE_WARN("EditorSubsystem::ExitPlayMode — skipping malformed manifest entry.");
-                continue;
-            }
-
-            const std::string lNameStr = lEntry["name"].get<std::string>();
-            const std::string lFileStr = lEntry["file"].get<std::string>();
-            const OpaaxStringID lNameID(lNameStr.c_str());
-
-            OPAAX_CORE_INFO("EditorSubsystem::ExitPlayMode — rebuilding scene '{}' from '{}'.",
-                lNameStr, lFileStr);
-
-            UniquePtr<Scene> lNew = SceneFactory::Create(lNameID);
-            if (!lNew)
-            {
-                OPAAX_CORE_ERROR("EditorSubsystem::ExitPlayMode — no SceneFactory entry for '{}'; skipping.",
-                    lNameStr);
-                continue;
-            }
-
-            Scene* lRawPtr = lNew.get();
-            lSceneMgr->Push(std::move(lNew));
-
-            // OnLoad may have spawned starter entities (e.g. ShmupGameScene's
-            // player). Wipe them — the snapshot is the authoritative state.
-            lWorld.DestroyEntitiesWithSceneID(lRawPtr->GetSceneID());
-
-            if (!SceneSerializer::Deserialize(*lRawPtr, lFileStr.c_str(), lWorld))
-            {
-                OPAAX_CORE_WARN("EditorSubsystem::ExitPlayMode — Deserialize failed for '{}'.", lNameStr);
-            }
-            ++lRestored;
-        }
-
-        // Roll back the persistent bucket. The Pop loop above intentionally
-        // does not touch PersistentSceneID entities (that's the persistence
-        // guarantee for runtime); for PIE we own the rollback semantic and
-        // restore them from the EnterPlayMode snapshot. Scenes are restored
-        // first so any persistent parent_uuid links can resolve against
-        // already-deserialized scene entities.
-        const OpaaxString lPersistentPath = OpaaxPath::ToAbsolute(PIE_TEMP_PERSISTENTS_PATH);
-        if (std::filesystem::exists(lPersistentPath.CStr()))
-        {
-            lWorld.DestroyEntitiesWithSceneID(World::PersistentSceneID);
-            if (!SceneSerializer::DeserializePersistents(lWorld, lPersistentPath.CStr()))
-            {
-                OPAAX_CORE_WARN("EditorSubsystem::ExitPlayMode — persistent restore failed.");
-            }
-        }
-        else
-        {
-            OPAAX_CORE_INFO("EditorSubsystem::ExitPlayMode — no persistent snapshot, skipping rollback.");
-        }
-
-        OPAAX_CORE_INFO("EditorSubsystem::ExitPlayMode — restored {} scene(s) from snapshot.", lRestored);
         SetEditorState(Editor::EEditorState::Editing);
+
+        // PIE rebuilds entities without going through SceneManager — publish so
+        // selection caches in Hierarchy / Inspector reset (entt recycles IDs).
+        OnNewSceneEvent lEvent;
+        m_EventBus->Publish(lEvent);
+        OPAAX_CORE_INFO("EditorSubsystem - OnNewSceneEvent published from ExitPlayMode");
     }
 
     void EditorSubsystem::EndFrame()

--- a/Engine/Source/Editor/EditorSubsystem.cpp
+++ b/Engine/Source/Editor/EditorSubsystem.cpp
@@ -94,6 +94,14 @@ namespace Opaax
 
         m_AssetBrowserPanel.Startup();
 
+        // Editor event bus: panels register handlers here. Tokens stored as panel
+        // members; RAII unsubscribe at panel destruction. Order is not meaningful —
+        // Publish dispatches in registration order per event type.
+        m_MainMenuBar.OnSubscribe(*m_EventBus);
+        m_HierarchyPanel.OnSubscribe(*m_EventBus);
+        m_InspectorPanel.OnSubscribe(*m_EventBus);
+        m_AssetBrowserPanel.OnSubscribe(*m_EventBus);
+
         GetEngineApp()->SetRenderTarget(&m_ViewportPanel);
 
         OPAAX_CORE_INFO("EditorSubsystem: ready.");

--- a/Engine/Source/Editor/EditorSubsystem.h
+++ b/Engine/Source/Editor/EditorSubsystem.h
@@ -85,10 +85,6 @@ namespace Opaax
         void PauseToggle();     // Playing ↔ Paused
         void ExitPlayMode();    // Playing|Paused → Editing  (restores scene from temp)
 
-        // Triggers an AssetBrowserPanel rescan — called by MainMenuBar after Save Scene As
-        // so a freshly written .scene.json shows up without a manual Refresh click.
-        void RefreshAssetBrowser();
-
         //------------------------------------------------------------------------------
         // Last-used dialog dir — volatile (lives for the editor session, no persistence).
         // Saved by MainMenuBar after a successful Open / SaveAs so the next dialog opens

--- a/Engine/Source/Editor/EditorSubsystem.h
+++ b/Engine/Source/Editor/EditorSubsystem.h
@@ -1,6 +1,7 @@
 #pragma once
 #if OPAAX_WITH_EDITOR
 
+#include "Editor/EditorEventBus.h"
 #include "Editor/EditorState.h"
 #include "Editor/IEditorPanel.h"
 #include "Panels/AssetBrowserPanel.h"
@@ -69,6 +70,8 @@ namespace Opaax
 
         FORCEINLINE Editor::EEditorState GetEditorState() const noexcept { return m_EditorState; }
 
+        FORCEINLINE Editor::EditorEventBus& GetEventBus() noexcept { return *m_EventBus; }
+
         // Panel visibility — references so the menu bar can toggle them in-place via ImGui::MenuItem.
         FORCEINLINE bool& GetShowHierarchyRef()    noexcept { return m_bShowHierarchy; }
         FORCEINLINE bool& GetShowInspectorRef()    noexcept { return m_bShowInspector; }
@@ -112,6 +115,11 @@ namespace Opaax
         void SetEditorState(Editor::EEditorState NewState);
 
     private:
+        // Bus is held by UniquePtr so the EditorSubsystem stays movable (default move
+        // ctor) — EditorEventBus itself is non-movable because SubscriptionTokens hold
+        // a raw EditorEventBus* and a relocation would silently dangle them.
+        UniquePtr<Editor::EditorEventBus> m_EventBus = MakeUnique<Editor::EditorEventBus>();
+
         Editor::MainMenuBar       m_MainMenuBar;
         Editor::HierarchyPanel    m_HierarchyPanel;
         Editor::InspectorPanel    m_InspectorPanel;

--- a/Engine/Source/Editor/Events/EditorEvents.h
+++ b/Engine/Source/Editor/Events/EditorEvents.h
@@ -1,0 +1,114 @@
+#pragma once
+#include <utility>
+
+#include "Core/Event/OpaaxEvent.hpp"
+#include "Core/OpaaxString.hpp"
+#include "Core/OpaaxStringID.hpp"
+#include "ECS/OpaaxEntity.hpp"
+
+// =============================================================================
+// EditorEvents.h
+//
+// All editor-side event classes dispatched through EditorEventBus.
+// Editor-only — game-layer code must NOT publish or subscribe to these
+// (call sites are gated by OPAAX_WITH_EDITOR).
+//
+// Each class uses the existing OPAAX_EVENT_CLASS_TYPE / CATEGORY macros so it
+// can also flow through the stack-local OpaaxEventDispatcher if a panel needs
+// classic single-dispatch handling.
+// =============================================================================
+
+namespace Opaax
+{
+    // =============================================================================
+    // Selection
+    // =============================================================================
+
+    /**
+     * @class OnEntitySelectedEvent
+     * Fired when the user picks an entity in the editor (e.g. HierarchyPanel click).
+     * Subscribers cache the entity; the bus does no retention.
+     */
+    class OPAAX_API OnEntitySelectedEvent final : public OpaaxEvent
+    {
+    public:
+        explicit OnEntitySelectedEvent(EntityID InEntity) noexcept
+            : m_Entity(InEntity)
+        {}
+
+        FORCEINLINE EntityID GetEntity() const noexcept { return m_Entity; }
+
+        OPAAX_EVENT_CLASS_TYPE(EEventType::EntitySelected)
+        OPAAX_EVENT_CLASS_CATEGORY(EEventCategory_Editor)
+
+    private:
+        EntityID m_Entity;
+    };
+
+    // =============================================================================
+    // Scene
+    // =============================================================================
+
+    /**
+     * @class OnSceneSavedEvent
+     * Fired after a successful scene write (Save As path). Payload is the absolute
+     * file path so consumers (e.g. AssetBrowserPanel) can scope a rescan.
+     */
+    class OPAAX_API OnSceneSavedEvent final : public OpaaxEvent
+    {
+    public:
+        explicit OnSceneSavedEvent(OpaaxString InPath) noexcept
+            : m_Path(std::move(InPath))
+        {}
+
+        FORCEINLINE const OpaaxString& GetPath() const noexcept { return m_Path; }
+
+        OPAAX_EVENT_CLASS_TYPE(EEventType::SceneSaved)
+        OPAAX_EVENT_CLASS_CATEGORY(EEventCategory_Editor)
+
+    private:
+        OpaaxString m_Path;
+    };
+
+    /**
+     * @class OnNewSceneEvent
+     * Fired when the active scene is replaced (New / Open / Replace). No payload —
+     * subscribers re-fetch from SceneManager at receipt. Gated by OPAAX_WITH_EDITOR
+     * at the SceneManager publish site so shipped game binaries don't carry the call.
+     */
+    class OPAAX_API OnNewSceneEvent final : public OpaaxEvent
+    {
+    public:
+        OnNewSceneEvent() noexcept = default;
+
+        OPAAX_EVENT_CLASS_TYPE(EEventType::NewScene)
+        OPAAX_EVENT_CLASS_CATEGORY(EEventCategory_Editor)
+    };
+
+    // =============================================================================
+    // Asset
+    // =============================================================================
+
+    /**
+     * @class OnAssetImportedEvent
+     * Fired when a new asset enters the registry (import action). AssetID is the
+     * canonical logical ID; Path is the on-disk location for browsers/inspectors.
+     */
+    class OPAAX_API OnAssetImportedEvent final : public OpaaxEvent
+    {
+    public:
+        OnAssetImportedEvent(OpaaxStringID InAssetID, OpaaxString InPath) noexcept
+            : m_AssetID(InAssetID), m_Path(std::move(InPath))
+        {}
+
+        FORCEINLINE OpaaxStringID         GetAssetID() const noexcept { return m_AssetID; }
+        FORCEINLINE const OpaaxString&    GetPath()    const noexcept { return m_Path; }
+
+        OPAAX_EVENT_CLASS_TYPE(EEventType::AssetImported)
+        OPAAX_EVENT_CLASS_CATEGORY(EEventCategory_Editor)
+
+    private:
+        OpaaxStringID m_AssetID;
+        OpaaxString   m_Path;
+    };
+}

--- a/Engine/Source/Editor/IEditorPanel.h
+++ b/Engine/Source/Editor/IEditorPanel.h
@@ -6,10 +6,15 @@
 
 namespace Opaax::Editor
 {
+    class EditorEventBus;
+
     /**
      * @class IEditorPanel
      * Base interface for all editor panels.
      * Startup/Shutdown manage GPU/resource lifecycle.
+     * OnSubscribe is called by EditorSubsystem immediately after Startup — override
+     *   to register handlers against the bus and store the returned SubscriptionTokens
+     *   as members (RAII unsubscribe on panel destruction).
      * Draw() handles per-frame ImGui content — override only when the panel takes no external params.
      * Panels with parameterised draw calls (Hierarchy, Inspector) inherit for lifecycle only.
      */
@@ -25,10 +30,11 @@ namespace Opaax::Editor
         // Function
         // =============================================================================
     public:
-        virtual void        Startup()                 {}
-        virtual void        Shutdown()                {}
-        virtual void        Draw()                    {}
-        virtual const char* GetPanelName() const      = 0;
+        virtual void        Startup()                            {}
+        virtual void        OnSubscribe(EditorEventBus& /*Bus*/) {}
+        virtual void        Shutdown()                           {}
+        virtual void        Draw()                               {}
+        virtual const char* GetPanelName() const                 = 0;
     };
 
 } // namespace Opaax::Editor

--- a/Engine/Source/Editor/Inspector/ComponentDrawerRegistry.cpp
+++ b/Engine/Source/Editor/Inspector/ComponentDrawerRegistry.cpp
@@ -1,2 +1,0 @@
-// Replaced by Opaax::ComponentRegistry (Engine/Source/ECS/ComponentRegistry.cpp) in M2.8.
-// Empty translation unit — physically delete this file when cleaning the tree.

--- a/Engine/Source/Editor/Inspector/ComponentDrawerRegistry.h
+++ b/Engine/Source/Editor/Inspector/ComponentDrawerRegistry.h
@@ -1,5 +1,0 @@
-#pragma once
-
-// Replaced by Opaax::ComponentRegistry (Engine/Source/ECS/ComponentRegistry.h) in M2.8.
-// This file is kept empty so the GLOB_RECURSE in CMakeLists.txt does not break;
-// physically delete it next time the working tree is cleaned.

--- a/Engine/Source/Editor/Inspector/IComponentDrawer.h
+++ b/Engine/Source/Editor/Inspector/IComponentDrawer.h
@@ -11,7 +11,7 @@ namespace Opaax::Editor
      * @class IComponentDrawer
      * Per-component ImGui drawer interface.
      * Implement one concrete class per component type.
-     * Register with ComponentDrawerRegistry::Register() at startup.
+     * Attach to a component type with ComponentRegistry::RegisterDrawer<T>() at startup.
      *
      * Draw()  — called each frame when HasComponent() is true.
      * Add()   — called from the "Add Component" popup when CanAdd() is true and the component is absent.

--- a/Engine/Source/Editor/Panels/AssetBrowserPanel.cpp
+++ b/Engine/Source/Editor/Panels/AssetBrowserPanel.cpp
@@ -13,6 +13,7 @@
 #include "Core/Config/ProjectConfig.h"
 #include "Editor/Assets/AssetTypeRegistry.h"
 #include "Editor/Assets/IAssetTypeActions.h"
+#include "Editor/Events/EditorEvents.h"
 #include "Scene/SceneManager.h"
 
 namespace Opaax::Editor
@@ -42,6 +43,20 @@ namespace Opaax::Editor
     {
         m_ManifestAbsPath = OpaaxPath::ToAbsolute(ProjectConfig::AssetsManifestRelPath());
         RunScan();
+    }
+
+    // =============================================================================
+    // Subscribe
+    // =============================================================================
+    void AssetBrowserPanel::OnSubscribe(EditorEventBus& InBus)
+    {
+        m_SceneSavedToken = InBus.Subscribe<OnSceneSavedEvent>(
+            [this](const OnSceneSavedEvent& InEvent)
+            {
+                OPAAX_CORE_INFO("AssetBrowserPanel - Scene saved received, rescanning: {}",
+                    InEvent.GetPath().CStr());
+                RunScan();
+            });
     }
 
     // =============================================================================

--- a/Engine/Source/Editor/Panels/AssetBrowserPanel.cpp
+++ b/Engine/Source/Editor/Panels/AssetBrowserPanel.cpp
@@ -21,16 +21,16 @@ namespace Opaax::Editor
     // Compares an entry's resolved abs path against SceneManager::GetCurrentScenePath()
     // via std::filesystem::equivalent so slash/case differences don't cause false negatives.
     // Returns false for non-Scene entries, missing files, or when no scene is loaded.
-    static bool IsLoadedScene(const SceneManager* InMgr, const AssetDescriptor& InDesc)
+    static bool IsLoadedScene(const SceneManager& InMgr, const AssetDescriptor& InDesc)
     {
-        if (!InMgr || !InMgr->HasCurrentScenePath()) { return false; }
-        if (InDesc.Type != OpaaxStringID("Scene"))   { return false; }
-        if (InDesc.bMissing)                         { return false; }
+        if (!InMgr.HasCurrentScenePath())          { return false; }
+        if (InDesc.Type != OpaaxStringID("Scene")) { return false; }
+        if (InDesc.bMissing)                       { return false; }
 
         std::error_code lEc;
         const OpaaxString lEntryAbs = OpaaxPath::ToAbsolute(InDesc.RelPath);
         const bool bSame = std::filesystem::equivalent(
-            std::filesystem::path(InMgr->GetCurrentScenePath().CStr()),
+            std::filesystem::path(InMgr.GetCurrentScenePath().CStr()),
             std::filesystem::path(lEntryAbs.CStr()),
             lEc);
         return bSame && !lEc;
@@ -93,12 +93,12 @@ namespace Opaax::Editor
     // =============================================================================
     // Draw
     // =============================================================================
-    void AssetBrowserPanel::Draw(SceneManager* InSceneManager)
+    void AssetBrowserPanel::Draw(SceneManager& InSceneMgr)
     {
         ImGui::Begin("Asset Browser");
         DrawToolbar();
         ImGui::Separator();
-        DrawAssetList(InSceneManager);
+        DrawAssetList(InSceneMgr);
         ImGui::End();
 
         // Deferred manifest mutation — safe to mutate s_Descriptors here, after iteration ended.
@@ -200,7 +200,7 @@ namespace Opaax::Editor
     // =============================================================================
     // Asset list
     // =============================================================================
-    void AssetBrowserPanel::DrawAssetList(SceneManager* InSceneManager)
+    void AssetBrowserPanel::DrawAssetList(SceneManager& InSceneMgr)
     {
         const auto& lAll = AssetManifest::GetAll();
 
@@ -215,7 +215,7 @@ namespace Opaax::Editor
         for (const auto& [lKey, lDesc] : lAll)
         {
             if (!m_Filter.Matches(lDesc)) { continue; }
-            DrawAssetEntry(lDesc, InSceneManager);
+            DrawAssetEntry(lDesc, InSceneMgr);
             ++lVisible;
         }
 
@@ -228,12 +228,12 @@ namespace Opaax::Editor
     // =============================================================================
     // Single entry — icon, colour, D&D source, tooltip, context menu
     // =============================================================================
-    void AssetBrowserPanel::DrawAssetEntry(const AssetDescriptor& InDesc, SceneManager* InSceneManager)
+    void AssetBrowserPanel::DrawAssetEntry(const AssetDescriptor& InDesc, SceneManager& InSceneMgr)
     {
         // Scenes don't go through AssetRegistry — they're owned by SceneManager.
         // Treat the entry that matches GetCurrentScenePath() as "loaded" for display parity with textures.
         const bool bLoaded  = AssetRegistry::IsLoaded(InDesc.ID)
-                           || IsLoadedScene(InSceneManager, InDesc);
+                           || IsLoadedScene(InSceneMgr, InDesc);
         const bool bMissing = InDesc.bMissing;
 
         // Status colour

--- a/Engine/Source/Editor/Panels/AssetBrowserPanel.h
+++ b/Engine/Source/Editor/Panels/AssetBrowserPanel.h
@@ -6,6 +6,7 @@
 #include "Core/OpaaxString.hpp"
 #include "Core/OpaaxStringID.hpp"
 #include "Assets/AssetScanner.h"
+#include "Editor/EditorEventBus.h"
 #include "Editor/IEditorPanel.h"
 #include "Editor/Panels/AssetBrowserFilter.h"
 
@@ -42,7 +43,7 @@ namespace Opaax::Editor
         // Functions
         // =============================================================================
     public:
-        // Public so EditorSubsystem can trigger a rescan after Save Scene As — see RefreshAssetBrowser().
+        // Public for the OnSceneSavedEvent subscriber + the manual Refresh toolbar button.
         void RunScan();
 
         // Primary entry point — called directly by EditorSubsystem (mirrors HierarchyPanel pattern).
@@ -59,10 +60,11 @@ namespace Opaax::Editor
         // =============================================================================
         //~Begin IEditorPanel interface
     public:
-        void        Startup()            override;
-        const char* GetPanelName() const override { return "Asset Browser"; }
+        void        Startup()                          override;
+        void        OnSubscribe(EditorEventBus& InBus) override;
+        const char* GetPanelName() const               override { return "Asset Browser"; }
         //~End IEditorPanel interface
-        
+
         // =============================================================================
         // Members
         // =============================================================================
@@ -76,6 +78,8 @@ namespace Opaax::Editor
         // Set inside DrawAssetEntry's context menu; processed once after the iteration
         // ends, so we never mutate AssetManifest::s_Descriptors while iterating it.
         OpaaxStringID            m_PendingRemoveID;
+
+        SubscriptionToken        m_SceneSavedToken;
     };
 
 } // namespace Opaax::Editor

--- a/Engine/Source/Editor/Panels/AssetBrowserPanel.h
+++ b/Engine/Source/Editor/Panels/AssetBrowserPanel.h
@@ -48,12 +48,12 @@ namespace Opaax::Editor
 
         // Primary entry point — called directly by EditorSubsystem (mirrors HierarchyPanel pattern).
         // The SceneManager is needed to mark the currently loaded scene as such in the list.
-        void Draw(SceneManager* InSceneManager);
+        void Draw(SceneManager& InSceneMgr);
 
     private:
         void DrawToolbar();
-        void DrawAssetList(SceneManager* InSceneManager);
-        void DrawAssetEntry(const AssetDescriptor& InDesc, SceneManager* InSceneManager);
+        void DrawAssetList(SceneManager& InSceneMgr);
+        void DrawAssetEntry(const AssetDescriptor& InDesc, SceneManager& InSceneMgr);
 
         // =============================================================================
         // Override

--- a/Engine/Source/Editor/Panels/HierarchyPanel.cpp
+++ b/Engine/Source/Editor/Panels/HierarchyPanel.cpp
@@ -152,20 +152,22 @@ namespace Opaax::Editor
         }
     }
 
-    void HierarchyPanel::Draw(Scene* InActiveScene, World* InWorld)
+    void HierarchyPanel::Draw(SceneManager& InSceneMgr, World& InWorld)
     {
         ImGui::Begin("Hierarchy");
 
-        // No scene active
-        if (!InActiveScene || !InWorld)
+        // Self-fetch active scene per frame — never cache Scene* across MainMenuBar.Draw
+        // or any other panel call. Stack top can change mid-DrawPanels (PIE Stop,
+        // New Scene, Open Scene) so the freshest read is the only safe one.
+        Scene* lScene = InSceneMgr.GetActiveScene();
+        if (!lScene)
         {
             ImGui::TextDisabled("No active scene.");
             ImGui::End();
             return;
         }
 
-        Scene* lScene    = InActiveScene;
-        World& lWorld    = *InWorld;
+        World& lWorld    = InWorld;
         auto&  lRegistry = lWorld.GetRegistry();
 
         // Scene name as header

--- a/Engine/Source/Editor/Panels/HierarchyPanel.cpp
+++ b/Engine/Source/Editor/Panels/HierarchyPanel.cpp
@@ -12,6 +12,8 @@
 #include "ECS/Components/SceneIDComponent.h"
 #include "ECS/Components/TagComponent.h"
 #include "ECS/Hierarchy.h"
+#include "Editor/EditorEventBus.h"
+#include "Editor/Events/EditorEvents.h"
 #include "World/World.h"
 
 namespace Opaax::Editor
@@ -120,6 +122,29 @@ namespace Opaax::Editor
         }
     }
 
+    void HierarchyPanel::OnSubscribe(EditorEventBus& InBus)
+    {
+        m_Bus = &InBus;
+    }
+
+    void HierarchyPanel::SetSelectedEntity(EntityID InEntity) { SetSelection(InEntity); }
+    void HierarchyPanel::ClearSelection()                     { SetSelection(ENTITY_NONE); }
+
+    void HierarchyPanel::SetSelection(EntityID InEntity)
+    {
+        if (InEntity == m_SelectedEntity) { return; } // idempotent — no spurious publishes
+
+        m_SelectedEntity = InEntity;
+
+        OPAAX_CORE_INFO("Hierarchy Panel - New Entity selected: {}", "Implement Entity::GetName");
+
+        if (m_Bus != nullptr)
+        {
+            OnEntitySelectedEvent lEvent{m_SelectedEntity};
+            m_Bus->Publish(lEvent);
+        }
+    }
+
     void HierarchyPanel::Draw(Scene* InActiveScene, World* InWorld)
     {
         ImGui::Begin("Hierarchy");
@@ -171,15 +196,20 @@ namespace Opaax::Editor
 
         // Render the tree. Collect a single delete request — the registry mutation
         // happens after iteration to avoid invalidating views mid-walk.
+        // DrawNode mutates its EntityID& parameter in-place on click; route through
+        // a local so SetSelection (which publishes) is the single sink.
+        EntityID lWorkingSelection = m_SelectedEntity;
         EntityID lToDelete = ENTITY_NONE;
         for (EntityID lRoot : lRoots)
         {
-            const EntityID lDel = DrawNode(lWorld, lRoot, lChildren, m_SelectedEntity);
+            const EntityID lDel = DrawNode(lWorld, lRoot, lChildren, lWorkingSelection);
             if (lDel != ENTITY_NONE && lToDelete == ENTITY_NONE)
             {
                 lToDelete = lDel;
             }
         }
+
+        SetSelection(lWorkingSelection);
 
         // Drop-to-root zone: the row IS the drop target AND the visible label, so the
         // user can never get confused about which surface receives the drop.
@@ -216,7 +246,7 @@ namespace Opaax::Editor
         if (ImGui::Button("+ Add Entity", ImVec2(-1.f, 0.f)))
         {
             const EntityID lNew = lWorld.CreateEntity("NewEntity");
-            m_SelectedEntity = lNew;
+            SetSelection(lNew);
         }
 
         ImGui::End();

--- a/Engine/Source/Editor/Panels/HierarchyPanel.cpp
+++ b/Engine/Source/Editor/Panels/HierarchyPanel.cpp
@@ -125,6 +125,13 @@ namespace Opaax::Editor
     void HierarchyPanel::OnSubscribe(EditorEventBus& InBus)
     {
         m_Bus = &InBus;
+
+        m_NewSceneToken = InBus.Subscribe<OnNewSceneEvent>(
+            [this](const OnNewSceneEvent&)
+            {
+                OPAAX_CORE_INFO("Hierarchy Panel - OnNewSceneEvent received, clearing selection");
+                SetSelection(ENTITY_NONE);
+            });
     }
 
     void HierarchyPanel::SetSelectedEntity(EntityID InEntity) { SetSelection(InEntity); }

--- a/Engine/Source/Editor/Panels/HierarchyPanel.h
+++ b/Engine/Source/Editor/Panels/HierarchyPanel.h
@@ -9,10 +9,13 @@
 
 namespace Opaax::Editor
 {
+    class EditorEventBus;
+
     /**
      * @class HierarchyPanel
      * Displays all entities in the active scene.
-     * Owns the "selected entity" state — other panels read from it via GetSelectedEntity().
+     * Owns the "selected entity" state — publishes OnEntitySelectedEvent on every
+     * change. Other panels subscribe via EditorEventBus (see Inspector).
      *
      * NOTE: Draw(Scene*, World*) is the primary entry point; it is called directly
      * by EditorSubsystem rather than through the IEditorPanel::Draw() interface.
@@ -40,26 +43,15 @@ namespace Opaax::Editor
         void Draw(Scene* InActiveScene, World* InWorld);
 
         //------------------------------------------------------------------------------
-        // Get - Set
-        FORCEINLINE EntityID GetSelectedEntity() const noexcept
-        {
-            return m_SelectedEntity;
-        }
-
-        FORCEINLINE void SetSelectedEntity(EntityID InEntity) noexcept
-        {
-            m_SelectedEntity = InEntity;
-        }
-
-        FORCEINLINE void ClearSelection() noexcept
-        {
-            m_SelectedEntity = ENTITY_NONE;
-        }
+        // Set — publish OnEntitySelectedEvent via the bus captured in OnSubscribe.
+        void SetSelectedEntity(EntityID InEntity);
+        void ClearSelection();
 
         // =============================================================================
         // Override
         // =============================================================================
         //~Begin IEditorPanel interface
+        void        OnSubscribe(EditorEventBus& InBus) override;
         const char* GetPanelName() const override { return "Hierarchy"; }
         //~End IEditorPanel interface
 
@@ -67,7 +59,11 @@ namespace Opaax::Editor
         // Members
         // =============================================================================
     private:
-        EntityID m_SelectedEntity = ENTITY_NONE;
+        /** Single mutation funnel — early-outs on same-value, then publishes. */
+        void SetSelection(EntityID InEntity);
+
+        EntityID        m_SelectedEntity = ENTITY_NONE;
+        EditorEventBus* m_Bus            = nullptr; // captured in OnSubscribe; non-owning
     };
 
 } // namespace Opaax::Editor

--- a/Engine/Source/Editor/Panels/HierarchyPanel.h
+++ b/Engine/Source/Editor/Panels/HierarchyPanel.h
@@ -16,10 +16,11 @@ namespace Opaax::Editor
      * Owns the "selected entity" state — publishes OnEntitySelectedEvent on every
      * change. Other panels subscribe via EditorEventBus (see Inspector).
      *
-     * NOTE: Draw(Scene*, World*) is the primary entry point; it is called directly
-     * by EditorSubsystem rather than through the IEditorPanel::Draw() interface.
-     * Caller supplies the active scene (for name + null-state) and the engine's
-     * shared World (entity source).
+     * NOTE: Draw(SceneManager&, World&) is the primary entry point; it is called
+     * directly by EditorSubsystem rather than through the IEditorPanel::Draw()
+     * interface. The panel self-fetches the active scene from the SceneManager at
+     * the top of every Draw — no Scene* cached across frames or upstream calls
+     * (structurally avoids the F7 dangling-Scene* class of bug).
      */
     class HierarchyPanel : public IEditorPanel
     {
@@ -36,10 +37,10 @@ namespace Opaax::Editor
     public:
         /**
          * API call by EditorSubsystem.
-         * @param InActiveScene active scene (null → render placeholder).
-         * @param InWorld       engine-shared World (must be non-null when InActiveScene is non-null).
+         * @param InSceneMgr active scene source (panel self-fetches GetActiveScene each frame).
+         * @param InWorld    engine-shared World (entity source).
          */
-        void Draw(Scene* InActiveScene, World* InWorld);
+        void Draw(SceneManager& InSceneMgr, World& InWorld);
 
         //------------------------------------------------------------------------------
         // Set — publish OnEntitySelectedEvent via the bus captured in OnSubscribe.

--- a/Engine/Source/Editor/Panels/HierarchyPanel.h
+++ b/Engine/Source/Editor/Panels/HierarchyPanel.h
@@ -5,12 +5,11 @@
 
 #include "Core/EngineAPI.h"
 #include "World/World.h"
+#include "Editor/EditorEventBus.h"
 #include "Editor/IEditorPanel.h"
 
 namespace Opaax::Editor
 {
-    class EditorEventBus;
-
     /**
      * @class HierarchyPanel
      * Displays all entities in the active scene.
@@ -62,8 +61,9 @@ namespace Opaax::Editor
         /** Single mutation funnel — early-outs on same-value, then publishes. */
         void SetSelection(EntityID InEntity);
 
-        EntityID        m_SelectedEntity = ENTITY_NONE;
-        EditorEventBus* m_Bus            = nullptr; // captured in OnSubscribe; non-owning
+        EntityID          m_SelectedEntity = ENTITY_NONE;
+        EditorEventBus*   m_Bus            = nullptr; // captured in OnSubscribe; non-owning
+        SubscriptionToken m_NewSceneToken;
     };
 
 } // namespace Opaax::Editor

--- a/Engine/Source/Editor/Panels/InspectorPanel.cpp
+++ b/Engine/Source/Editor/Panels/InspectorPanel.cpp
@@ -16,6 +16,13 @@ namespace Opaax::Editor
                 m_SelectedEntity = InEvent.GetEntity();
                 OPAAX_CORE_INFO("Inspector Panel - New Entity selected: {}", "Implement Entity::GetName");
             });
+
+        m_NewSceneToken = InBus.Subscribe<OnNewSceneEvent>(
+            [this](const OnNewSceneEvent&)
+            {
+                OPAAX_CORE_INFO("Inspector Panel - OnNewSceneEvent received, clearing cached entity");
+                m_SelectedEntity = ENTITY_NONE;
+            });
     }
 
     void InspectorPanel::Draw(World* InWorld)

--- a/Engine/Source/Editor/Panels/InspectorPanel.cpp
+++ b/Engine/Source/Editor/Panels/InspectorPanel.cpp
@@ -25,11 +25,11 @@ namespace Opaax::Editor
             });
     }
 
-    void InspectorPanel::Draw(World* InWorld)
+    void InspectorPanel::Draw(World& InWorld)
     {
         ImGui::Begin("Inspector");
 
-        if (!InWorld || m_SelectedEntity == ENTITY_NONE)
+        if (m_SelectedEntity == ENTITY_NONE)
         {
             ImGui::TextDisabled("No entity selected.");
             ImGui::End();
@@ -39,14 +39,14 @@ namespace Opaax::Editor
         // IsValid gate stays — the cache is advisory; an entity destroyed by a
         // path that doesn't publish (game system, future code) would otherwise
         // dereference an invalid handle.
-        if (!InWorld->IsValid(m_SelectedEntity))
+        if (!InWorld.IsValid(m_SelectedEntity))
         {
             ImGui::TextDisabled("Entity is no longer valid.");
             ImGui::End();
             return;
         }
 
-        ComponentDrawerRegistry::DrawAll(*InWorld, m_SelectedEntity);
+        ComponentDrawerRegistry::DrawAll(InWorld, m_SelectedEntity);
 
         ImGui::Separator();
 
@@ -57,7 +57,7 @@ namespace Opaax::Editor
 
         if (ImGui::BeginPopup("AddComponentPopup"))
         {
-            ComponentDrawerRegistry::DrawAddComponentMenu(*InWorld, m_SelectedEntity);
+            ComponentDrawerRegistry::DrawAddComponentMenu(InWorld, m_SelectedEntity);
             ImGui::EndPopup();
         }
 

--- a/Engine/Source/Editor/Panels/InspectorPanel.cpp
+++ b/Engine/Source/Editor/Panels/InspectorPanel.cpp
@@ -3,29 +3,43 @@
 #if OPAAX_WITH_EDITOR
 
 #include <imgui.h>
-#include "ECS/ComponentRegistry.h"
+#include "Editor/Events/EditorEvents.h"
+#include "Editor/Inspector/ComponentDrawerRegistry.h"
 
 namespace Opaax::Editor
 {
-    void InspectorPanel::Draw(World* InWorld, EntityID InSelected)
+    void InspectorPanel::OnSubscribe(EditorEventBus& InBus)
+    {
+        m_SelectionToken = InBus.Subscribe<OnEntitySelectedEvent>(
+            [this](const OnEntitySelectedEvent& InEvent)
+            {
+                m_SelectedEntity = InEvent.GetEntity();
+                OPAAX_CORE_INFO("Inspector Panel - New Entity selected: {}", "Implement Entity::GetName");
+            });
+    }
+
+    void InspectorPanel::Draw(World* InWorld)
     {
         ImGui::Begin("Inspector");
 
-        if (!InWorld || InSelected == ENTITY_NONE)
+        if (!InWorld || m_SelectedEntity == ENTITY_NONE)
         {
             ImGui::TextDisabled("No entity selected.");
             ImGui::End();
             return;
         }
 
-        if (!InWorld->IsValid(InSelected))
+        // IsValid gate stays — the cache is advisory; an entity destroyed by a
+        // path that doesn't publish (game system, future code) would otherwise
+        // dereference an invalid handle.
+        if (!InWorld->IsValid(m_SelectedEntity))
         {
             ImGui::TextDisabled("Entity is no longer valid.");
             ImGui::End();
             return;
         }
 
-        ComponentRegistry::DrawAll(*InWorld, InSelected);
+        ComponentDrawerRegistry::DrawAll(*InWorld, m_SelectedEntity);
 
         ImGui::Separator();
 
@@ -36,7 +50,7 @@ namespace Opaax::Editor
 
         if (ImGui::BeginPopup("AddComponentPopup"))
         {
-            ComponentRegistry::DrawAddComponentMenu(*InWorld, InSelected);
+            ComponentDrawerRegistry::DrawAddComponentMenu(*InWorld, m_SelectedEntity);
             ImGui::EndPopup();
         }
 

--- a/Engine/Source/Editor/Panels/InspectorPanel.cpp
+++ b/Engine/Source/Editor/Panels/InspectorPanel.cpp
@@ -4,7 +4,7 @@
 
 #include <imgui.h>
 #include "Editor/Events/EditorEvents.h"
-#include "Editor/Inspector/ComponentDrawerRegistry.h"
+#include "ECS/ComponentRegistry.h"
 
 namespace Opaax::Editor
 {
@@ -46,7 +46,7 @@ namespace Opaax::Editor
             return;
         }
 
-        ComponentDrawerRegistry::DrawAll(InWorld, m_SelectedEntity);
+        ComponentRegistry::DrawAll(InWorld, m_SelectedEntity);
 
         ImGui::Separator();
 
@@ -57,7 +57,7 @@ namespace Opaax::Editor
 
         if (ImGui::BeginPopup("AddComponentPopup"))
         {
-            ComponentDrawerRegistry::DrawAddComponentMenu(InWorld, m_SelectedEntity);
+            ComponentRegistry::DrawAddComponentMenu(InWorld, m_SelectedEntity);
             ImGui::EndPopup();
         }
 

--- a/Engine/Source/Editor/Panels/InspectorPanel.h
+++ b/Engine/Source/Editor/Panels/InspectorPanel.h
@@ -17,8 +17,9 @@ namespace Opaax::Editor
      * in OnSubscribe). The panel caches the selection in m_SelectedEntity and reads
      * from the cache each frame — Draw takes only the World.
      *
-     * Extension: register an IComponentDrawer via ComponentDrawerRegistry::Register()
-     * to support a new component type. No changes required here.
+     * Extension: register an IComponentDrawer for a component type via
+     * ComponentRegistry::RegisterDrawer<T>() to customise its Inspector view.
+     * No changes required here.
      */
     class InspectorPanel : public IEditorPanel
     {

--- a/Engine/Source/Editor/Panels/InspectorPanel.h
+++ b/Engine/Source/Editor/Panels/InspectorPanel.h
@@ -4,13 +4,18 @@
 
 #include "Core/EngineAPI.h"
 #include "World/World.h"
+#include "Editor/EditorEventBus.h"
 #include "Editor/IEditorPanel.h"
 
 namespace Opaax::Editor
 {
     /**
      * @class InspectorPanel
-     * Displays and edits components of the selected entity.
+     * Displays and edits components of the currently selected entity.
+     *
+     * Selection arrives via OnEntitySelectedEvent on the EditorEventBus (subscribed
+     * in OnSubscribe). The panel caches the selection in m_SelectedEntity and reads
+     * from the cache each frame — Draw takes only the World.
      *
      * Extension: register an IComponentDrawer via ComponentDrawerRegistry::Register()
      * to support a new component type. No changes required here.
@@ -29,18 +34,25 @@ namespace Opaax::Editor
         // =============================================================================
     public:
         /**
-         * API — parameterised draw called directly by EditorSubsystem
-         * @param InWorld 
-         * @param InSelected 
+         * API — parameterised draw called directly by EditorSubsystem.
+         * @param InWorld engine-shared World (entity source).
          */
-        void Draw(World* InWorld, EntityID InSelected);
+        void Draw(World* InWorld);
 
         // =============================================================================
         // Override
         // =============================================================================
         //~Begin  IEditorPanel interface
+        void        OnSubscribe(EditorEventBus& InBus) override;
         const char* GetPanelName() const override { return "Inspector"; }
         //~End  IEditorPanel interface
+
+        // =============================================================================
+        // Members
+        // =============================================================================
+    private:
+        EntityID          m_SelectedEntity = ENTITY_NONE;
+        SubscriptionToken m_SelectionToken;
     };
 
 } // namespace Opaax::Editor

--- a/Engine/Source/Editor/Panels/InspectorPanel.h
+++ b/Engine/Source/Editor/Panels/InspectorPanel.h
@@ -37,7 +37,7 @@ namespace Opaax::Editor
          * API — parameterised draw called directly by EditorSubsystem.
          * @param InWorld engine-shared World (entity source).
          */
-        void Draw(World* InWorld);
+        void Draw(World& InWorld);
 
         // =============================================================================
         // Override

--- a/Engine/Source/Editor/Panels/InspectorPanel.h
+++ b/Engine/Source/Editor/Panels/InspectorPanel.h
@@ -53,6 +53,7 @@ namespace Opaax::Editor
     private:
         EntityID          m_SelectedEntity = ENTITY_NONE;
         SubscriptionToken m_SelectionToken;
+        SubscriptionToken m_NewSceneToken;
     };
 
 } // namespace Opaax::Editor

--- a/Engine/Source/Editor/Toolbar/MainMenuBar.cpp
+++ b/Engine/Source/Editor/Toolbar/MainMenuBar.cpp
@@ -6,8 +6,10 @@
 #include <imgui.h>
 #include <tinyfiledialogs.h>
 
+#include "Editor/EditorEventBus.h"
 #include "Editor/EditorState.h"
 #include "Editor/EditorSubsystem.h"
+#include "Editor/Events/EditorEvents.h"
 #include "Core/CoreEngineApp.h"
 #include "Core/Log/OpaaxLog.h"
 #include "Core/OpaaxPath.h"
@@ -305,8 +307,8 @@ namespace Opaax::Editor
         if (lPath && lMgr->SaveAs(lPath))
         {
             RememberDialogDir(Owner, lPath);
-            // Auto-refresh so the new file appears in the Asset Browser without a manual Refresh.
-            Owner.RefreshAssetBrowser();
+            OPAAX_CORE_INFO("MainMenuBar - Scene saved: {}", lPath);
+            Owner.GetEventBus().Publish(OnSceneSavedEvent{OpaaxString(lPath)});
         }
     }
 

--- a/Engine/Source/Scene/SceneManager.cpp
+++ b/Engine/Source/Scene/SceneManager.cpp
@@ -8,6 +8,12 @@
 #include "Core/OpaaxPath.h"
 #include "World/World.h"
 
+#if OPAAX_WITH_EDITOR
+#include "Editor/EditorEventBus.h"
+#include "Editor/EditorSubsystem.h"
+#include "Editor/Events/EditorEvents.h"
+#endif
+
 namespace Opaax
 {
     // =============================================================================
@@ -91,6 +97,10 @@ namespace Opaax
 
         m_Stack.push_back(std::move(InScene));
         SyncCurrentSceneFromActive();
+
+#if OPAAX_WITH_EDITOR
+        PublishNewSceneEvent("Replace");
+#endif
     }
 
     void SceneManager::SaveCurrentSave()
@@ -182,6 +192,10 @@ namespace Opaax
         m_CurrentScenePath = InPath;
         lScene->SetSourcePath(m_CurrentScenePath);
         OPAAX_CORE_INFO("SceneManager::Open — loaded '{}'.", InPath);
+
+#if OPAAX_WITH_EDITOR
+        PublishNewSceneEvent("Open");
+#endif
         return true;
     }
 
@@ -246,7 +260,23 @@ namespace Opaax
 
         m_CurrentScenePath.Clear();
         OPAAX_CORE_INFO("SceneManager::NewScene — scene entities cleared.");
+
+#if OPAAX_WITH_EDITOR
+        PublishNewSceneEvent("NewScene");
+#endif
     }
+
+#if OPAAX_WITH_EDITOR
+    void SceneManager::PublishNewSceneEvent(const char* InSource)
+    {
+        EditorSubsystem* lEditor = GetEngineApp() ? GetEngineApp()->GetSubsystem<EditorSubsystem>() : nullptr;
+        if (!lEditor) { return; }
+
+        OnNewSceneEvent lEvent;
+        lEditor->GetEventBus().Publish(lEvent);
+        OPAAX_CORE_INFO("SceneManager - OnNewSceneEvent published from {}", InSource);
+    }
+#endif
 
     void SceneManager::SyncCurrentSceneFromActive()
     {

--- a/Engine/Source/Scene/SceneManager.h
+++ b/Engine/Source/Scene/SceneManager.h
@@ -170,6 +170,12 @@ namespace Opaax
         // its state into the manager without a back-pointer.
         void SyncCurrentSceneFromActive();
 
+#if OPAAX_WITH_EDITOR
+        // Reaches the editor's bus via GetEngineApp()->GetSubsystem<EditorSubsystem>().
+        // Null-safe — early-out if the editor subsystem isn't alive yet (init/shutdown windows).
+        void PublishNewSceneEvent(const char* InSource);
+#endif
+
         TDynArray<UniquePtr<Scene>> m_Stack;
         OpaaxString                 m_CurrentScenePath;
         OpaaxStringID               m_CurrentSceneAssetID;

--- a/Game/Assets/AssetManifest.json
+++ b/Game/Assets/AssetManifest.json
@@ -1,8 +1,8 @@
 {
     "assets": [
         {
-            "id": "Scenes/untitled",
-            "path": "Game/Assets/Scenes/untitled.scene.json",
+            "id": "Scenes/TestSaveEvent",
+            "path": "Game/Assets/Scenes/TestSaveEvent.scene.json",
             "type": "Scene"
         },
         {

--- a/Game/Assets/AssetManifest.json
+++ b/Game/Assets/AssetManifest.json
@@ -1,11 +1,6 @@
 {
     "assets": [
         {
-            "id": "Scenes/TestSaveEvent",
-            "path": "Game/Assets/Scenes/TestSaveEvent.scene.json",
-            "type": "Scene"
-        },
-        {
             "id": "Scenes/GameScene",
             "path": "Game/Assets/Scenes/GameScene.scene.json",
             "type": "Scene"

--- a/Game/Assets/AssetManifest.json
+++ b/Game/Assets/AssetManifest.json
@@ -14,6 +14,11 @@
             "id": "Scenes/Test",
             "path": "Game/Assets/Scenes/Test.scene.json",
             "type": "Scene"
+        },
+        {
+            "id": "Scenes/untitled",
+            "path": "Game/Assets/Scenes/untitled.scene.json",
+            "type": "Scene"
         }
     ]
 }

--- a/SimpleShmup/Assets/AssetManifest.json
+++ b/SimpleShmup/Assets/AssetManifest.json
@@ -1,6 +1,11 @@
 {
     "assets": [
         {
+            "id": "Textures/Explosion Pack/PNG/Pixel explosion/pixelExplosion04",
+            "path": "SimpleShmup/Assets/Textures/Explosion Pack/PNG/Pixel explosion/pixelExplosion04.png",
+            "type": "Texture2D"
+        },
+        {
             "id": "Textures/Explosion Pack/PNG/Pixel explosion/pixelExplosion05",
             "path": "SimpleShmup/Assets/Textures/Explosion Pack/PNG/Pixel explosion/pixelExplosion05.png",
             "type": "Texture2D"
@@ -303,11 +308,6 @@
         {
             "id": "Textures/Explosion Pack/PNG/Pixel explosion/pixelExplosion03",
             "path": "SimpleShmup/Assets/Textures/Explosion Pack/PNG/Pixel explosion/pixelExplosion03.png",
-            "type": "Texture2D"
-        },
-        {
-            "id": "Textures/Explosion Pack/PNG/Pixel explosion/pixelExplosion04",
-            "path": "SimpleShmup/Assets/Textures/Explosion Pack/PNG/Pixel explosion/pixelExplosion04.png",
             "type": "Texture2D"
         },
         {


### PR DESCRIPTION
Move editor direct call in panel by using event bus system.

Panels trigger their own work base on editor event (New Scene, Scene saved, new entity selected etc...)